### PR TITLE
chore: release v0.1.1

### DIFF
--- a/iconoclast/CHANGELOG.md
+++ b/iconoclast/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.1.0...iconoclast-v0.1.1) - 2025-05-26
+
+### Added
+
+- feat! update signature of consumer/message handler
+- implement re-usable service-configuration
+
+### Other
+
+- refine crate-documentation
+- retrofit CHANGELOG for 0.1.0
+
 ## [0.1.0](https://github.com/elmarx/iconoclast/releases/tag/iconoclast-v0.1.0) - 2025-05-18
 
 ### Added

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iconoclast"
 description = "Reusable code for Rust-based business μServices"
 repository = "https://github.com/elmarx/iconoclast"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 readme = "README.md"
 authors = ["Elmar Athmer"]


### PR DESCRIPTION



## 🤖 New release

* `iconoclast`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.1.0...iconoclast-v0.1.1) - 2025-05-26

### Added

- feat! update signature of consumer/message handler
- implement re-usable service-configuration

### Other

- refine crate-documentation
- retrofit CHANGELOG for 0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).