### PR TITLE
chore: release v0.3.1

### DIFF
--- a/examples/hexagonal/web/Cargo.toml
+++ b/examples/hexagonal/web/Cargo.toml
@@ -12,6 +12,7 @@ axum-extra = { version = "0.10.1", features = ["error-response"] }
 application = { path = "../application" }
 futures = "0.3.31"
 itertools = "0.14.0"
+askama = "0.14.0"
 
 [dev-dependencies]
 tower = { version = "0.5.2", features = ["util"] }

--- a/examples/hexagonal/web/templates/_layout.css
+++ b/examples/hexagonal/web/templates/_layout.css
@@ -1,0 +1,3 @@
+body {
+  background-color: #f0f0f0;
+}

--- a/examples/hexagonal/web/templates/_layout.html
+++ b/examples/hexagonal/web/templates/_layout.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Iconoclast Hexagonal Demo</title>
+
+  <style>
+    /*<![CDATA[*/
+        {%~ include "_layout.css" ~%}
+    /*]]>*/
+  </style>
+</head>
+<body>
+{%~ block content %}{% endblock ~%}
+</body>
+</html>

--- a/examples/hexagonal/web/templates/index.html
+++ b/examples/hexagonal/web/templates/index.html
@@ -1,0 +1,13 @@
+{% extends "_layout.html" %}
+
+{% block content %}
+<h1>Task List</h1>
+
+<div>There are {{ tasks.len() }} todos.</div>
+
+<ul>
+  {% for task in tasks %}
+  <li> {{ task | fmt("{:?}") }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/iconoclast/CHANGELOG.md
+++ b/iconoclast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.0...iconoclast-v0.3.1) - 2025-06-03
+
+### Fixed
+
+- *(deps)* update rust crate tracing-opentelemetry to 0.31.0
+
 ## [0.3.0](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.2.0...iconoclast-v0.3.0) - 2025-06-03
 
 ### Added

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iconoclast"
 description = "Reusable code for Rust-based business μServices"
 repository = "https://github.com/elmarx/iconoclast"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 readme = "README.md"
 authors = ["Elmar Athmer"]

--- a/skeleton/web/Cargo.toml
+++ b/skeleton/web/Cargo.toml
@@ -12,6 +12,7 @@ axum-extra = { version = "0.10.1", features = ["error-response"] }
 application = { path = "../application" }
 futures = "0.3.31"
 itertools = "0.14.0"
+askama = "0.14.0"
 
 [dev-dependencies]
 tower = { version = "0.5.2", features = ["util"] }

--- a/skeleton/web/templates/_layout.html
+++ b/skeleton/web/templates/_layout.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Iconoclast Hexagonal Skeleton</title>
+
+  <style>
+    /*<![CDATA[*/
+        {%~ include "_layout.css" ~%}
+    /*]]>*/
+  </style>
+</head>
+<body>
+{%~ block content %}{% endblock ~%}
+</body>
+</html>

--- a/skeleton/web/templates/index.html
+++ b/skeleton/web/templates/index.html
@@ -1,0 +1,5 @@
+{% extends "_layout.html" %}
+
+{% block content %}
+Hello World
+{% endblock %}


### PR DESCRIPTION



## 🤖 New release

* `iconoclast`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.0...iconoclast-v0.3.1) - 2025-06-03

### Fixed

- *(deps)* update rust crate tracing-opentelemetry to 0.31.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).