### PR TITLE
chore: release v0.3.1

### DIFF
--- a/iconoclast/CHANGELOG.md
+++ b/iconoclast/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.0...iconoclast-v0.3.1) - 2025-06-03
+
+### Fixed
+
+- *(deps)* update rust crate tracing-opentelemetry to 0.31.0
+
+### Other
+
+- implement a health-service with hyper
+- make the axum-management service a feature
+
 ## [0.3.0](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.2.0...iconoclast-v0.3.0) - 2025-06-03
 
 ### Added

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iconoclast"
 description = "Reusable code for Rust-based business μServices"
 repository = "https://github.com/elmarx/iconoclast"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 readme = "README.md"
 authors = ["Elmar Athmer"]

--- a/skeleton/.github/workflows/test-and-build.yaml
+++ b/skeleton/.github/workflows/test-and-build.yaml
@@ -1,9 +1,13 @@
-name: test
+name: Test and Build
 on: [ push, pull_request ]
+
+env:
+  REGISTRY: # TODO skeleton: add the registry here
+  IMAGE_NAME: # TODO: skeleton: add the image name here
 
 jobs:
   test:
-    name: test iconoclast
+    name: compile, lint, test
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
@@ -29,12 +33,33 @@ jobs:
         with:
           args: --all-features --all-targets
 
+  build:
+    name: build docker image
+    runs-on: ubuntu-latest
+    needs: [ test ]
+    steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      # TODO skeleton: login to container registry
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=branch,suffix=-${{ github.run_number }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/skeleton/Cargo.toml
+++ b/skeleton/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["application", "domain", "errors", "kafka", "main", "repository", "web"]
+
+[profile.dev.package.sqlx-macros]
+opt-level = 3


### PR DESCRIPTION



## 🤖 New release

* `iconoclast`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.0...iconoclast-v0.3.1) - 2025-06-03

### Fixed

- *(deps)* update rust crate tracing-opentelemetry to 0.31.0

### Other

- implement a health-service with hyper
- make the axum-management service a feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).