### PR TITLE
chore: release v0.3.2

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v5.0.0
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v42.0.6
         with:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5.0.0
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v42.0.6
+        uses: renovatebot/github-action@v43.0.12
         with:
           configurationFile: .github/renovate-global.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
@@ -41,7 +41,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -73,7 +73,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -90,7 +90,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ "test", "skeleton", "skeleton_oci", "skeleton_oci_from_source" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: make the skeleton available
         uses: actions/upload-artifact@v4
         with:

--- a/examples/demo/logic/Cargo.toml
+++ b/examples/demo/logic/Cargo.toml
@@ -10,12 +10,12 @@ faux = ["dep:faux"]
 [dependencies]
 faux = { version = "0.1.12", optional = true }
 repository = { path = "../repository" }
-thiserror = "2.0.12"
+thiserror = "2.0.16"
 tracing = "0.1.41"
 model = { path = "../model" }
 
 [dev-dependencies]
 faux = "0.1.12"
 repository = { path = "../repository", features = ["faux"] }
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
 

--- a/examples/demo/model/Cargo.toml
+++ b/examples/demo/model/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-thiserror = "2.0.12"
+thiserror = "2.0.16"

--- a/examples/demo/repository/Cargo.toml
+++ b/examples/demo/repository/Cargo.toml
@@ -6,14 +6,14 @@ description = "Repository Layer for service"
 publish = false
 
 [dependencies]
-sqlx = { version = "0.8.5", features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres"] }
-thiserror = "2.0.12"
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres"] }
+thiserror = "2.0.16"
 faux = { version = "0.1.12", optional = true }
 
 [dev-dependencies]
-testcontainers = "0.24.0"
-testcontainers-modules = { version = "0.12.0", features = ["postgres"] }
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
+testcontainers = "0.25.0"
+testcontainers-modules = { version = "0.13.0", features = ["postgres"] }
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
 faux = "0.1.12"
 
 [features]

--- a/examples/demo/uservice/Cargo.toml
+++ b/examples/demo/uservice/Cargo.toml
@@ -12,7 +12,7 @@ gcloud = [
 ]
 
 [dependencies]
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 repository = { path = "../repository" }
 iconoclast = { features = ["kafka", "persistence"], path = "../../../iconoclast" }

--- a/examples/demo/uservice/Cargo.toml
+++ b/examples/demo/uservice/Cargo.toml
@@ -15,7 +15,7 @@ gcloud = [
 tokio = { version = "1.44.2", features = ["full"] }
 tracing = "0.1.41"
 repository = { path = "../repository" }
-iconoclast = { features = ["kafka"], path = "../../../iconoclast" }
+iconoclast = { features = ["kafka", "persistence"], path = "../../../iconoclast" }
 model = { path = "../model" }
 logic = { path = "../logic" }
 web = { path = "../web" }

--- a/examples/demo/web/Cargo.toml
+++ b/examples/demo/web/Cargo.toml
@@ -9,17 +9,17 @@ default = ["template"]
 template = ["dep:askama"]
 
 [dependencies]
-axum = { version = "0.8.3", features = ["macros"] }
+axum = { version = "0.8.4", features = ["macros"] }
 axum-extra = { version = "0.10.1", features = ["error-response"] }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.225", features = ["derive"] }
 logic = { path = "../logic" }
 askama = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
 tower = { version = "0.5.2", features = ["util"] }
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 http-body-util = "0.1.3"
 faux = "0.1.12"
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
 logic = { path = "../logic", features = ["faux"] }
 

--- a/examples/hexagonal/application/Cargo.toml
+++ b/examples/hexagonal/application/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 domain = { path = "../domain" }
 errors = { path = "../errors" }
 futures = "0.3.31"
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 
 [dev-dependencies]
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
 mockall = "0.13.1"

--- a/examples/hexagonal/domain/Cargo.toml
+++ b/examples/hexagonal/domain/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uuid = { version = "1.17.0", features = ["v4"] }
+uuid = { version = "1.18.1", features = ["v4"] }

--- a/examples/hexagonal/kafka/Cargo.toml
+++ b/examples/hexagonal/kafka/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 domain = { path = "../domain" }
 application = { path = "../application" }
 rdkafka = { version = "0.38.0", default-features = false }
-uuid = { version = "1.17.0", features = ["v4"] }
-thiserror = "2.0.12"
+uuid = { version = "1.18.1", features = ["v4"] }
+thiserror = "2.0.16"
 iconoclast = { features = ["kafka"], path = "../../../iconoclast" }
 futures = "0.3.31"

--- a/examples/hexagonal/main/Cargo.toml
+++ b/examples/hexagonal/main/Cargo.toml
@@ -10,7 +10,7 @@ adapter-repository = { path = "../repository" }
 adapter-kafka = { path = "../kafka" }
 adapter-web = { path = "../web" }
 iconoclast = { features = ["kafka"], path = "../../../iconoclast" }
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 futures = "0.3.31"
 

--- a/examples/hexagonal/repository/Cargo.toml
+++ b/examples/hexagonal/repository/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 
 [dependencies]
 application = { path = "../application" }
-sqlx = { version = "0.8.5", features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "uuid"] }
 domain = { path = "../domain" }
 errors = { path = "../errors" }
 futures = "0.3.31"
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 
 [dev-dependencies]
-testcontainers-modules = { version = "0.12.0", features = ["postgres", "blocking"] }
-testcontainers = { version = "0.24.0", features = ["reusable-containers"] }
-ctor = "0.4.2"
+testcontainers-modules = { version = "0.13.0", features = ["postgres", "blocking"] }
+testcontainers = { version = "0.25.0", features = ["reusable-containers"] }
+ctor = "0.5.0"

--- a/examples/hexagonal/web/Cargo.toml
+++ b/examples/hexagonal/web/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 domain = { path = "../domain" }
 errors = { path = "../errors" }
-axum = { version = "0.8.3", features = ["macros"] }
+axum = { version = "0.8.4", features = ["macros"] }
 axum-extra = { version = "0.10.1", features = ["error-response"] }
 application = { path = "../application" }
 futures = "0.3.31"
@@ -16,7 +16,7 @@ askama = "0.14.0"
 
 [dev-dependencies]
 tower = { version = "0.5.2", features = ["util"] }
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 http-body-util = "0.1.3"
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
-async-trait = "0.1.88"
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
+async-trait = "0.1.89"

--- a/iconoclast/CHANGELOG.md
+++ b/iconoclast/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.1...iconoclast-v0.3.2) - 2025-09-19
+
+### Added
+
+- support openapi via utoipa
+- feat! make database/persistence optional
+
+### Fixed
+
+- *(deps)* update rust crate rdkafka to 0.38.0
+
+### Other
+
+- upgrade dependencies
+
 ## [0.3.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.0...iconoclast-v0.3.1) - 2025-06-04
 
 ### Added

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -40,25 +40,25 @@ utoipa = [
 
 
 [dependencies]
-axum = { version = "0.8.3", default-features = false, features = ["json", "tokio", "http1"] }
+axum = { version = "0.8.4", default-features = false, features = ["json", "tokio", "http1"] }
 listenfd = { version = "1.0.2", optional = true }
 rdkafka = { version = "0.38.0", features = ["sasl", "ssl", "zstd"], optional = true }
-serde = { version = "1.0.219", features = ["derive"] }
-tokio = { version = "1.44.2", features = ["io-std", "net"] }
+serde = { version = "1.0.225", features = ["derive"] }
+tokio = { version = "1.47.1", features = ["io-std", "net"] }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 tracing-stackdriver = { version = "0.10.0", features = ["http", "opentelemetry"], optional = true }
 tracing-opentelemetry = { version = "0.31.0", optional = true }
-hyper-util = { version = "0.1.11", features = ["client-legacy"], optional = true }
+hyper-util = { version = "0.1.17", features = ["client-legacy"], optional = true }
 http-body-util = { version = "0.1.3", optional = true }
-hyper = { version = "1.6.0", optional = true }
-thiserror = "2.0.12"
+hyper = { version = "1.7.0", optional = true }
+thiserror = "2.0.16"
 futures = { version = "0.3.31", optional = true }
 tokio-stream = { version = "0.1.17", optional = true }
 tower-livereload = { version = "0.9.6", optional = true }
-config = { version = "0.15.11", features = ["toml"], optional = true }
+config = { version = "0.15.16", features = ["toml"], optional = true }
 tower = { version = "0.5.2", optional = true }
-serde_with = "3.12.0"
+serde_with = "3.14.0"
 utoipa = { version = "5.4.0", optional = true, features = ["axum_extras"] }
 utoipa-axum = { version = "0.2.0", optional = true }
 utoipa-swagger-ui = { version = "9.0.2", optional = true, features = ["axum", "vendored"] }

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -32,6 +32,11 @@ mgmt-hyper = [
     "dep:tower"
 ]
 persistence = []
+utoipa = [
+    "dep:utoipa",
+    "dep:utoipa-axum",
+    "dep:utoipa-swagger-ui"
+]
 
 
 [dependencies]
@@ -54,6 +59,9 @@ tower-livereload = { version = "0.9.6", optional = true }
 config = { version = "0.15.11", features = ["toml"], optional = true }
 tower = { version = "0.5.2", optional = true }
 serde_with = "3.12.0"
+utoipa = { version = "5.4.0", optional = true, features = ["axum_extras"] }
+utoipa-axum = { version = "0.2.0", optional = true }
+utoipa-swagger-ui = { version = "9.0.2", optional = true, features = ["axum", "vendored"] }
 
 [dev-dependencies]
 faux = "0.1.12"

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -31,6 +31,7 @@ mgmt-hyper = [
     "dep:http-body-util",
     "dep:tower"
 ]
+persistence = []
 
 
 [dependencies]

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iconoclast"
 description = "Reusable code for Rust-based business μServices"
 repository = "https://github.com/elmarx/iconoclast"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 readme = "README.md"
 authors = ["Elmar Athmer"]

--- a/iconoclast/src/config/service.rs
+++ b/iconoclast/src/config/service.rs
@@ -1,7 +1,7 @@
 use crate::config::builder::ServiceConfig;
 use crate::config::iconoclast;
 use serde::Deserialize;
-use serde_with::{NoneAsEmptyString, serde_as};
+use serde_with::serde_as;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
@@ -9,8 +9,9 @@ pub struct DefaultServiceConfig {
     /// generic configuration for all iconoclast-like services
     pub iconoclast: iconoclast::Config,
 
+    #[cfg(feature = "persistence")]
     // if no url (or an empty string) is given, connection parameters will be read from env: https://docs.rs/sqlx/latest/sqlx/postgres/struct.PgConnectOptions.html#parameters
-    #[serde_as(as = "NoneAsEmptyString")]
+    #[serde_as(as = "serde_with::NoneAsEmptyString")]
     pub database_url: Option<String>,
 
     /// kafka configuration

--- a/iconoclast/src/server.rs
+++ b/iconoclast/src/server.rs
@@ -1,11 +1,74 @@
-use axum::Router;
 use tokio::io;
 use tokio::net::TcpListener;
+
+#[cfg(not(feature = "utoipa"))]
+type Router = axum::Router;
+
+#[cfg(feature = "utoipa")]
+type Router = utoipa_axum::router::OpenApiRouter;
+
+pub struct Server {
+    port: u16,
+    router: Router,
+
+    #[cfg(feature = "utoipa")]
+    swagger_path: String,
+
+    #[cfg(feature = "utoipa")]
+    apispec_path: String,
+}
+
+impl Server {
+    pub fn new(router: Router) -> Self {
+        Self {
+            port: 8080,
+            router,
+
+            #[cfg(feature = "utoipa")]
+            swagger_path: "/swagger-ui".to_string(),
+
+            #[cfg(feature = "utoipa")]
+            apispec_path: "/apidoc/openapi.json".to_string(),
+        }
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    #[cfg(feature = "utoipa")]
+    pub fn with_swagger_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.swagger_path = path.into();
+        self
+    }
+
+    #[cfg(feature = "utoipa")]
+    pub fn with_apispec_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.apispec_path = path.into();
+        self
+    }
+
+    #[cfg(not(feature = "utoipa"))]
+    pub async fn start(self) -> Result<(), io::Error> {
+        start(self.port, self.router).await
+    }
+
+    #[cfg(feature = "utoipa")]
+    pub async fn start(self) -> Result<(), io::Error> {
+        let (router, api) = self.router.split_for_parts();
+        let router = router.merge(
+            utoipa_swagger_ui::SwaggerUi::new(self.swagger_path).url(self.apispec_path, api),
+        );
+
+        start(self.port, router).await
+    }
+}
 
 /// # Errors
 ///
 /// May fail to bind to the given port.
-pub async fn start(port: u16, app: Router) -> Result<(), io::Error> {
+pub async fn start(port: u16, app: axum::Router) -> Result<(), io::Error> {
     #[cfg(feature = "listenfd")]
     let listener = {
         let mut listenfd = listenfd::ListenFd::from_env();

--- a/skeleton/.github/workflows/test-and-build.yaml
+++ b/skeleton/.github/workflows/test-and-build.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3
 
       # TODO skeleton: login to container registry

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -58,10 +58,10 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -y libssl3 libsasl2-2
 ENV ICONOCLAST_LOGGING=json
-RUN adduser --system iconoclast
+RUN useradd -r iconoclast
 COPY --from=builder /usr/local/bin/iconoclastd /usr/local/bin
 
 USER iconoclast
-WORKDIR /home/iconoclast
+WORKDIR /var/lib/iconoclast
 
 CMD [ "iconoclastd" ]

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -54,7 +54,7 @@ RUN if [ "$ICONOCLAST_SOURCE" != "0" ]; then echo "[patch.\"crates-io\"]\n\nicon
 # and finally compile the actual code
 RUN cargo install --locked --path main --root /usr/local
 
-FROM debian:stable-slim
+FROM debian:trixie-20250908-slim
 
 RUN apt-get update && apt-get install -y libssl3 libsasl2-2
 ENV ICONOCLAST_LOGGING=json

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -23,6 +23,9 @@ COPY main/Cargo.toml main/
 COPY repository/Cargo.toml repository/
 COPY web/Cargo.toml web/
 
+# patch workspace file to use iconoclast from source
+RUN if [ "$ICONOCLAST_SOURCE" != "0" ]; then echo "[patch.\"crates-io\"]\n\niconoclast = { git = \"https://github.com/elmarx/iconoclast.git\", rev = \"$ICONOCLAST_SOURCE\" }" >> Cargo.toml; fi;
+
 # compile all dependencies with a dummy for improved caching
 RUN mkdir -p main/src/bin && \
   touch application/src/lib.rs && \
@@ -47,9 +50,6 @@ COPY web web
 
 # update the timestamps so cargo picks up the actual code
 RUN touch application/src/lib.rs domain/src/lib.rs errors/src/lib.rs kafka/src/lib.rs repository/src/lib.rs web/src/lib.rs
-
-# patch workspace file to use iconoclast from source
-RUN if [ "$ICONOCLAST_SOURCE" != "0" ]; then echo "[patch.\"crates-io\"]\n\niconoclast = { git = \"https://github.com/elmarx/iconoclast.git\", rev = \"$ICONOCLAST_SOURCE\" }" >> Cargo.toml; fi;
 
 # and finally compile the actual code
 RUN cargo install --locked --path main --root /usr/local

--- a/skeleton/Dockerfile
+++ b/skeleton/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87.0 AS builder
+FROM rust:1.90.0 AS builder
 # build iconoclast from source directly
 ARG ICONOCLAST_SOURCE=0
 WORKDIR /usr/src/service

--- a/skeleton/application/Cargo.toml
+++ b/skeleton/application/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 domain = { path = "../domain" }
 errors = { path = "../errors" }
 futures = "0.3.31"
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 
 [dev-dependencies]
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
 mockall = "0.13.1"

--- a/skeleton/domain/Cargo.toml
+++ b/skeleton/domain/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uuid = { version = "1.17.0", features = ["v4"] }
+uuid = { version = "1.18.1", features = ["v4"] }

--- a/skeleton/kafka/Cargo.toml
+++ b/skeleton/kafka/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 domain = { path = "../domain" }
 application = { path = "../application" }
 rdkafka = { version = "0.38.0", default-features = false }
-uuid = { version = "1.17.0", features = ["v4"] }
-thiserror = "2.0.12"
+uuid = { version = "1.18.1", features = ["v4"] }
+thiserror = "2.0.16"
 iconoclast = { features = ["kafka"], version = "0.3.1" }
 futures = "0.3.31"

--- a/skeleton/main/Cargo.toml
+++ b/skeleton/main/Cargo.toml
@@ -10,7 +10,7 @@ adapter-repository = { path = "../repository" }
 adapter-kafka = { path = "../kafka" }
 adapter-web = { path = "../web" }
 iconoclast = { features = ["kafka", "persistence"], version = "0.3.1" }
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 futures = "0.3.31"
 

--- a/skeleton/main/Cargo.toml
+++ b/skeleton/main/Cargo.toml
@@ -9,7 +9,7 @@ application = { path = "../application" }
 adapter-repository = { path = "../repository" }
 adapter-kafka = { path = "../kafka" }
 adapter-web = { path = "../web" }
-iconoclast = { features = ["kafka"], version = "0.3.1" }
+iconoclast = { features = ["kafka", "persistence"], version = "0.3.1" }
 tokio = { version = "1.44.2", features = ["full"] }
 tracing = "0.1.41"
 futures = "0.3.31"
@@ -18,4 +18,4 @@ futures = "0.3.31"
 tikv-jemallocator = "0.6"
 
 [dev-dependencies]
-iconoclast = { features = ["kafka", "livereload"], version = "0.3.1" }
+iconoclast = { features = ["kafka", "persistence", "livereload"], version = "0.3.1" }

--- a/skeleton/repository/Cargo.toml
+++ b/skeleton/repository/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 
 [dependencies]
 application = { path = "../application" }
-sqlx = { version = "0.8.5", features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "uuid"] }
 domain = { path = "../domain" }
 errors = { path = "../errors" }
 futures = "0.3.31"
-async-trait = "0.1.88"
+async-trait = "0.1.89"
 
 [dev-dependencies]
-testcontainers-modules = { version = "0.12.0", features = ["postgres", "blocking"] }
-testcontainers = { version = "0.24.0", features = ["reusable-containers"] }
-ctor = "0.4.2"
+testcontainers-modules = { version = "0.13.0", features = ["postgres", "blocking"] }
+testcontainers = { version = "0.25.0", features = ["reusable-containers"] }
+ctor = "0.5.0"

--- a/skeleton/web/Cargo.toml
+++ b/skeleton/web/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 domain = { path = "../domain" }
 errors = { path = "../errors" }
-axum = { version = "0.8.3", features = ["macros"] }
+axum = { version = "0.8.4", features = ["macros"] }
 axum-extra = { version = "0.10.1", features = ["error-response"] }
 application = { path = "../application" }
 futures = "0.3.31"
@@ -16,7 +16,7 @@ askama = "0.14.0"
 
 [dev-dependencies]
 tower = { version = "0.5.2", features = ["util"] }
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 http-body-util = "0.1.3"
-tokio = { version = "1.44.2", default-features = false, features = ["rt", "macros"] }
-async-trait = "0.1.88"
+tokio = { version = "1.47.1", default-features = false, features = ["rt", "macros"] }
+async-trait = "0.1.89"


### PR DESCRIPTION



## 🤖 New release

* `iconoclast`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.1...iconoclast-v0.3.2) - 2025-09-19

### Added

- support openapi via utoipa
- feat! make database/persistence optional

### Fixed

- *(deps)* update rust crate rdkafka to 0.38.0

### Other

- upgrade dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).