### PR TITLE
chore: release v0.4.0

### DIFF
--- a/iconoclast/CHANGELOG.md
+++ b/iconoclast/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.1...iconoclast-v0.4.0) - 2025-11-29
+
+### Added
+
+- support openapi via utoipa
+- [**breaking**] make database/persistence optional
+
+### Fixed
+
+- apply some clippy must_use suggestions
+- allow clippy violation (in testcode)
+- properly export ServiceConfig
+- *(deps)* update rust crate rdkafka to 0.38.0
+
+### Other
+
+- add missing documentation for potential errors
+- upgrade dependencies
+
 ## [0.3.1](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.0...iconoclast-v0.3.1) - 2025-06-04
 
 ### Added

--- a/iconoclast/Cargo.toml
+++ b/iconoclast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iconoclast"
 description = "Reusable code for Rust-based business μServices"
 repository = "https://github.com/elmarx/iconoclast"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 readme = "README.md"
 authors = ["Elmar Athmer"]


### PR DESCRIPTION



## 🤖 New release

* `iconoclast`: 0.3.1 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/elmarx/iconoclast/compare/iconoclast-v0.3.1...iconoclast-v0.4.0) - 2025-11-29

### Added

- support openapi via utoipa
- [**breaking**] make database/persistence optional

### Fixed

- apply some clippy must_use suggestions
- allow clippy violation (in testcode)
- properly export ServiceConfig
- *(deps)* update rust crate rdkafka to 0.38.0

### Other

- add missing documentation for potential errors
- upgrade dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).